### PR TITLE
Fixed "widget-control.c:251:22: error: implicit declaration of function 'finish'

### DIFF
--- a/widget-control.c
+++ b/widget-control.c
@@ -62,6 +62,8 @@ int *feature_first_value;
 // int feature_last_value[feature_end_index];
 int *feature_last_value;
 
+int finish(int return_value);
+
 void feature_first_and_last_init(void) {
 	int i, j;
 	feature_first_value[true_feature_major_index] = -1;


### PR DESCRIPTION
# Before

```
Link widget.elf
make[1]: Leaving directory `C:/Users/AHysing/code/sdr-widget/Release'
gcc -o widget-control widget-control.c -lusb-1.0
widget-control.c: In function 'setup':
widget-control.c:251:22: error: implicit declaration of function 'finish' [-Wimplicit-function-declaration]
  251 |                 exit(finish(1));
      |                      ^~~~~~
make: *** [widget-control] Error 1
```

## After

```
make
./make-widget
make[1]: Entering directory `C:/Users/AHysing/code/sdr-widget/Release'
make[1]: Nothing to be done for `all'.
make[1]: Leaving directory `C:/Users/AHysing/code/sdr-widget/Release'
gcc -o widget-control widget-control.c -lusb-1.0
```

Closes borgestrand/sdr-widget#4